### PR TITLE
Remove API key instruction text from component

### DIFF
--- a/app/[[...slug]]/page.tsx
+++ b/app/[[...slug]]/page.tsx
@@ -26,7 +26,6 @@ export default function MyComponent(props: any) {
               >
                 builder.io
               </a>
-              <span>and copy your API key from the settings.</span>
             </li>
             <li className="step-item">
               <strong className="step-label">Update your environment:</strong>


### PR DESCRIPTION
Removes the span element containing the text "and copy your API key from the settings." from the step item in the component.

This change simplifies the instruction text by removing the API key copying guidance.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/a7c91b85fa6d4284bdd4132d31dc9e76/zenith-garden)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>a7c91b85fa6d4284bdd4132d31dc9e76</projectId>-->
<!--<branchName>zenith-garden</branchName>-->